### PR TITLE
Chore(devcontainer): Update image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,5 @@
   "extensions": [
     "ms-python.python",
     "ms-toolsai.jupyter"
-  ],
-  "features": {
-    "github-cli": "latest"
-  }
+  ]
 }

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   jupyter:
-    image: utkusarioglu/conda-econ-devcontainer:1.0.0
+    image: utkusarioglu/conda-econ-devcontainer:1.0.4
     volumes:
       - ..:/utkusarioglu-com/workshops/bea-workshop

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,13 +6,11 @@
       "type": "pythonEnvironment"
     },
   ],
-  "emeraldwalk.runonsave": {
-    "commands": [
-      {
-        "match": ".env*",
-        "isAsync": true,
-        "cmd": "/scripts/create-env-example.sh"
-      },
-    ]
-  },
+  "runOnSave.commands": [
+    {
+      "match": ".env*",
+      "isAsync": true,
+      "command": "/scripts/create-env-example.sh"
+    },
+  ]
 }


### PR DESCRIPTION
- Switch to devcontainer version `1.0.4`. This update does the
  following:
  * Remove the need for installing github cli
  * Replace vim with nvim
  * Switch to extension `runOnSave` for run on save functionality for
    vscode.
- Remove gh cli from devcontainer features
- Alter vscode settings to use `runOnsave`.
