### PR TITLE
Chore(devcontainer): Upgrade image version

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   jupyter:
-    image: utkusarioglu/conda-econ-devcontainer:1.0.4
+    image: utkusarioglu/conda-econ-devcontainer:1.0.5
     volumes:
       - ..:/utkusarioglu-com/workshops/bea-workshop


### PR DESCRIPTION
- Switch to image version `1.0.5`, which offers better support for
  vscode extensions volumes.
